### PR TITLE
Updates based on larnd2supera and propagation of G4ID and trigger info for CAFs

### DIFF
--- a/bin/run_flow2supera.py
+++ b/bin/run_flow2supera.py
@@ -11,8 +11,12 @@ parser.add_option("-c", "--config", dest="config", metavar='FILE/KEYWORD', defau
                   help="Configuration keyword or a file path (full or relative including the file name)")
 parser.add_option("-n", "--num_events", dest="num_events", metavar="INT", default=-1,
                   help="number of events to process")
+parser.add_option("-f", "--num_flash_events", dest="num_flash_events", metavar="INT", default=-1,
+                  help="number of flash events to process")
 parser.add_option("-s", "--skip", dest="skip", metavar="INT", default=0,
                   help="number of first events to skip")
+parser.add_option("-x", "--num_flash_skip", dest="num_flash_skip", metavar="INT", default=0,
+                  help="number of first flash events to skip")
 #parser.add_option("-b", action="store_true", dest="ignore_bad_association", default=False)
 parser.add_option("-l", "--log", dest="log_file", metavar="FILE", default='',
                   help="the name of a log file to be created. ")
@@ -55,7 +59,9 @@ flow2supera.utils.run_supera(out_file=data.output_filename,
     in_file=args[0],
     config_key=data.config,
     num_events=int(data.num_events),
+    num_flash_events=int(data.num_flash_events),
     num_skip=int(data.skip),
+    num_flash_skip=int(data.num_flash_skip),
     #ignore_bad_association=bool(data.ignore_bad_association),
     save_log=data.log_file,
     )

--- a/src/flow2supera/config_data/2x2.yaml
+++ b/src/flow2supera/config_data/2x2.yaml
@@ -20,9 +20,14 @@ BBoxConfig:
     #BBoxSize:   [141.888,127.6992,141.888]
     #BBoxTop:    [70.944,105.8496,70.944]
     #BBoxBottom: [-70.944,-21.8496,-70.944]
-    BBoxSize:   [129.0,  127.0, 131.0]
-    BBoxTop:    [64.5,  -203.0, 1365.5]
-    BBoxBottom: [-64.5, -330.0, 1234.5]
+    #BBoxSize:   [129.0,  127.0, 131.0]
+    #BBoxTop:    [64.5,  -203.0, 1365.5]
+    #BBoxBottom: [-64.5, -330.0, 1234.5]
+    
+    #taken from larnd2supera for MR4
+    BBoxSize:   [141.888,127.6992,141.888]
+    BBoxTop:    [70.944,-204.1504,1370.944]
+    BBoxBottom: [-70.944,-331.8496,1229.056]
     VoxelSize:  [0.4434,0.4434,0.4434]
     #WorldBoundMax: [-1.e20,-1.e20,-1.e20]
     #WorldBoundMin: [ 1.e20, 1.e20, 1.e20]

--- a/src/flow2supera/config_data/2x2.yaml
+++ b/src/flow2supera/config_data/2x2.yaml
@@ -42,5 +42,6 @@ LabelConfig:
     StoreLEScatter:   True
     SemanticPriority: [1,0,2,3,4]
     EnergyDepositThreshold: 0.0
+    RewriteInteractionID:  False
     #WorldBoundMax: [-1.e20,-1.e20,-1.e20]
     #WorldBoundMin: [ 1.e20, 1.e20, 1.e20]

--- a/src/flow2supera/driver.py
+++ b/src/flow2supera/driver.py
@@ -233,7 +233,8 @@ class SuperaDriver(edep2supera.edep2supera.SuperaDriver):
         p.id             = int(trajectory['event_id'])
         p.interaction_id = int(trajectory['vertex_id'])
         p.trackid        = int(trajectory['traj_id']) # Unique among all files used in truth-matching for MLreco
-        p.local_traj_id  = int(trajectory['local_traj_id']) # Not unique among all files, G4ID propagated from edep-sim, needed for inter-detector matching in ND_CAFMaker
+        if hasattr(p, "genid") and trajectory["parent_id"] < 0:# < 0 indicates a top-level particle (from GENIE)
+            p.genid = int(trajectory['local_traj_id'])
         p.pdg            = int(trajectory['pdg_id'])
         p.px = trajectory['pxyz_start'][0] 
         p.py = trajectory['pxyz_start'][1] 

--- a/src/flow2supera/driver.py
+++ b/src/flow2supera/driver.py
@@ -206,10 +206,10 @@ class SuperaDriver(edep2supera.edep2supera.SuperaDriver):
         for i_bt, backtracked_hit in enumerate(backtracked_hits):
             reco_hit = data.hits[i_bt]
             for contrib in range(max_contributors):
-                if abs(backtracked_hit['fraction'][contrib]) < hit_threshold: continue
-
-                # Store hit information in Supera's EDep class. Add EDeps to 
-                # pcloud (std::vector<Supera::EDep>) for labeling 
+                if abs(backtracked_hit['fraction'][contrib]) == 0: continue
+                #from larnd2supera, 2023-09-14 YC: 
+                #I think frac_min should be allowed to be below 0 for the sake of induced current. 
+                #SK: So, only skipping 0 
                 edep = supera.EDep()
                 edep.x = reco_hit['x']
                 edep.y = reco_hit['y']

--- a/src/flow2supera/driver.py
+++ b/src/flow2supera/driver.py
@@ -222,7 +222,7 @@ class SuperaDriver(edep2supera.edep2supera.SuperaDriver):
 
     def TrajectoryToParticle(self, trajectory):
         ### What we have access to in new flow format: ###
-        # ('event_id', 'vertex_id', 'traj_id', 'traj_id', 'parent_id', 'E_start', 'pxyz_start', 
+        # ('event_id', 'vertex_id', 'traj_id', 'local_traj_id', 'parent_id', 'E_start', 'pxyz_start', 
         # 'xyz_start', 't_start', 'E_end', 'pxyz_end', 'xyz_end', 't_end', 'pdg_id', 
         # 'start_process', 'start_subprocess', 'end_process', 'end_subprocess')
         ###############################################################################################
@@ -232,7 +232,8 @@ class SuperaDriver(edep2supera.edep2supera.SuperaDriver):
         # but Supera/LArCV want a regular int, hence the type casting
         p.id             = int(trajectory['event_id'])
         p.interaction_id = int(trajectory['vertex_id'])
-        p.trackid        = int(trajectory['traj_id']) # TODO Is this right? What exactly is traj_id?
+        p.trackid        = int(trajectory['traj_id']) # Unique among all files used in truth-matching for MLreco
+        p.local_traj_id  = int(trajectory['local_traj_id']) # Not unique among all files, G4ID propagated from edep-sim, needed for inter-detector matching in ND_CAFMaker
         p.pdg            = int(trajectory['pdg_id'])
         p.px = trajectory['pxyz_start'][0] 
         p.py = trajectory['pxyz_start'][1] 

--- a/src/flow2supera/driver.py
+++ b/src/flow2supera/driver.py
@@ -323,10 +323,10 @@ class SuperaDriver(edep2supera.edep2supera.SuperaDriver):
                     else:
                         print("    WARNING: UNEXPECTED CASE for IONIZATION ")
                         print("      PDG",pdg_code,
-                              "TrackId",edepsim_part['traj_id'],
+                              "TrackId",edepsim_part['trackID'],
                               "Kinetic Energy",ke,
                               "Parent PDG",supera_part.parent_pdg ,
-                              "Parent TrackId",edepsim_part['parent_id'],
+                              "Parent TrackId",edepsim_part['parentID'],
                               "G4ProcessType",g4type_main ,
                               "SubProcessType",g4type_sub)
                         supera_part.type = supera.kIonization

--- a/src/flow2supera/driver.py
+++ b/src/flow2supera/driver.py
@@ -323,10 +323,10 @@ class SuperaDriver(edep2supera.edep2supera.SuperaDriver):
                     else:
                         print("    WARNING: UNEXPECTED CASE for IONIZATION ")
                         print("      PDG",pdg_code,
-                              "TrackId",edepsim_part['trackID'],
+                              "TrackId",edepsim_part['traj_id'],
                               "Kinetic Energy",ke,
                               "Parent PDG",supera_part.parent_pdg ,
-                              "Parent TrackId",edepsim_part['parentID'],
+                              "Parent TrackId",edepsim_part['parent_id'],
                               "G4ProcessType",g4type_main ,
                               "SubProcessType",g4type_sub)
                         supera_part.type = supera.kIonization

--- a/src/flow2supera/driver.py
+++ b/src/flow2supera/driver.py
@@ -368,26 +368,3 @@ class SuperaDriver(edep2supera.edep2supera.SuperaDriver):
                     supera_part.type = supera.kOtherShower
         else:
             supera_part.type = supera.kTrack
-
-    def ReadFlash(self, data, verbose=False):
-        
-        
-        hits = data.sipm_hits
-        
-        supera_flash = supera.FlashEventInput()
-        supera_flash.reserve(len(hits))
-        
-        print('Len hits:', len(hits))        
-        for i, hit in enumerate(hits):
-            flash_input = supera.FlashInput()
-            flash_input.valid = True
-            flash_input.flashev = self.HitsToFlash(hit) 
-            supera_flash.push_back(flash_input)
-        print('Len supera_flash:', len(supera_flash))
-        return supera_flash
-
-    def HitsToFlash(self, hit):
-        f = supera.Flash()
-        f.id = hit['id']
-        return f
-    

--- a/src/flow2supera/driver.py
+++ b/src/flow2supera/driver.py
@@ -368,3 +368,26 @@ class SuperaDriver(edep2supera.edep2supera.SuperaDriver):
                     supera_part.type = supera.kOtherShower
         else:
             supera_part.type = supera.kTrack
+
+    def ReadFlash(self, data, verbose=False):
+        
+        
+        hits = data.sipm_hits
+        
+        supera_flash = supera.FlashEventInput()
+        supera_flash.reserve(len(hits))
+        
+        print('Len hits:', len(hits))        
+        for i, hit in enumerate(hits):
+            flash_input = supera.FlashInput()
+            flash_input.valid = True
+            flash_input.flashev = self.HitsToFlash(hit) 
+            supera_flash.push_back(flash_input)
+        print('Len supera_flash:', len(supera_flash))
+        return supera_flash
+
+    def HitsToFlash(self, hit):
+        f = supera.Flash()
+        f.id = hit['id']
+        return f
+    

--- a/src/flow2supera/reader.py
+++ b/src/flow2supera/reader.py
@@ -125,7 +125,7 @@ class FlowReader:
         and fills segment and trajectory IDs corresponding to hits. 
         '''
         max_contributors = 100
-        hit_threshold = 0.0001
+        #hit_threshold = 0.0001
         #backtracked_hits = self._backtracked_hits
         # TODO Calculate the length of this in advance and use reserve; appending is slow!
         truth_dict = {
@@ -137,7 +137,10 @@ class FlowReader:
         trajectory_ids = []
         for i_bt, backtracked_hit in enumerate(backtracked_hits):
             for contrib in range(max_contributors):
-                if abs(backtracked_hit['fraction'][contrib]) < hit_threshold: continue
+                if abs(backtracked_hit['fraction'][contrib]) == 0: continue
+                #from larnd2supera, 2023-09-14 YC: 
+                #I think frac_min should be allowed to be below 0 for the sake of induced current. 
+                #SK: So, only skipping 0 
                 segment_id = backtracked_hit['segment_id'][contrib]
                 segment = segments[segment_id]
                 segment_ids.append(segment_id)

--- a/src/flow2supera/reader.py
+++ b/src/flow2supera/reader.py
@@ -29,6 +29,8 @@ class FlowReader:
             raise TypeError('Input file must be a str type')
         self._event_ids = None
         self._event_t0s = None
+        self._flash_t0s = None
+        self._flash_ids = None
         self._event_hit_indices = None
         self._hits = None
         self._backtracked_hits = None
@@ -100,6 +102,9 @@ class FlowReader:
                 self._segments = flow_manager[segments_path+'data']
                 self._trajectories = flow_manager[trajectories_path]
                 self._interactions = flow_manager[interactions_path]
+            flash_events = flow_manager[light_events_data_path]['data']
+            self._flash_ids = flash_events['id']
+           # self.flash_t0s = flash_events['tai_ns']
 
                 
         # This next bit is only necessary if reading multiple files

--- a/src/flow2supera/reader.py
+++ b/src/flow2supera/reader.py
@@ -15,6 +15,12 @@ class InputEvent:
     segment_index_min = -1
     event_separator = ''
 
+class InputFlash:
+    flash_id = -1
+    sipm_hits = None
+    sum_hits = None
+    t0 = -1
+
 class FlowReader:
     
     def __init__(self, parser_run_config, input_files=None):
@@ -59,7 +65,7 @@ class FlowReader:
         # H5Flow's H5FlowDataManager class associated datasets through references
         # These paths help us get the correct associations
         events_path = 'charge/events/'
-        t0s_path = '/combined/t0/'
+        light_events_data_path = 'light/events/data'
         events_data_path = 'charge/events/data/'
         event_hit_indices_path = 'charge/events/ref/charge/calib_final_hits/ref_region/'
         calib_final_hits_path = 'charge/calib_final_hits/'

--- a/src/flow2supera/reader.py
+++ b/src/flow2supera/reader.py
@@ -1,7 +1,7 @@
 import h5py 
 import h5flow
 import numpy as np
-from ROOT import supera
+#from ROOT import supera
 import cppyy
 
 class InputEvent:
@@ -205,68 +205,68 @@ class FlowReader:
         print('interactions in this event:', len(input_event.interactions))
 
 
-class FlowFlashReader:
+# class FlowFlashReader:
     
-    def __init__(self, parser_run_config, input_files=None):
-        self._input_files = input_files
-        if not isinstance(input_files, str):
-            raise TypeError('Input file must be a str type')
+#     def __init__(self, parser_run_config, input_files=None):
+#         self._input_files = input_files
+#         if not isinstance(input_files, str):
+#             raise TypeError('Input file must be a str type')
         
-        self._flash_t0s = None
-        self._flash_ids = None
-        self._hit_indices = None
-        self._sipm_hits = None
+#         self._flash_t0s = None
+#         self._flash_ids = None
+#         self._hit_indices = None
+#         self._sipm_hits = None
        
 
-        if input_files:
-            self.ReadFlash(input_files)
+#         if input_files:
+#             self.ReadFlash(input_files)
 
-    def __len__(self):
-        if self._flash_ids is None: return 0
-        return len(self._flash_ids)
+#     def __len__(self):
+#         if self._flash_ids is None: return 0
+#         return len(self._flash_ids)
 
     
-    def __iter__(self):
-        for entry in range(len(self)):
-            yield self.GetEvent(entry)
+#     def __iter__(self):
+#         for entry in range(len(self)):
+#             yield self.GetEvent(entry)
 
-    def ReadFlash(self, input_files, verbose=False):
-        flash_events_path = 'light/events/data'
-        hits_ref_region = 'light/events/ref/light/sipm_hits/ref_region'
-        sipm_hits = 'light/sipm_hits/data'
-        flow_manager = h5flow.data.H5FlowDataManager(input_files, 'r')
-        with h5py.File(input_files, 'r') as fin:
-            flash_events = flow_manager[flash_events_path]
-            self._flash_ids = flash_events['id']
-            self._flash_t0s = flash_events['tai_ns'].flatten()
-            self._hit_indices = flow_manager[hits_ref_region]
-            self._sipm_hits = flow_manager[sipm_hits]
+#     def ReadFlash(self, input_files, verbose=False):
+#         flash_events_path = 'light/events/data'
+#         hits_ref_region = 'light/events/ref/light/sipm_hits/ref_region'
+#         sipm_hits = 'light/sipm_hits/data'
+#         flow_manager = h5flow.data.H5FlowDataManager(input_files, 'r')
+#         with h5py.File(input_files, 'r') as fin:
+#             flash_events = flow_manager[flash_events_path]
+#             self._flash_ids = flash_events['id']
+#             self._flash_t0s = flash_events['tai_ns'].flatten()
+#             self._hit_indices = flow_manager[hits_ref_region]
+#             self._sipm_hits = flow_manager[sipm_hits]
     
-    def GetFlash(self, event_index):
+#     def GetFlash(self, event_index):
         
-        if event_index >= len(self._flash_ids):
-            print('Entry {} is above allowed entry index ({})'.format(event_index, len(self._flash_ids)))
-            print('Invalid read request (returning None)')
-            return None
+#         if event_index >= len(self._flash_ids):
+#             print('Entry {} is above allowed entry index ({})'.format(event_index, len(self._flash_ids)))
+#             print('Invalid read request (returning None)')
+#             return None
         
-        result = supera.Flash()
-        result.id = self._flash_ids[event_index]
-        result.time = self._flash_t0s[event_index*8]/1000. #TO DO: why are there 8 entries? (TPC times?) How to handle this?#  
+#         result = supera.Flash()
+#         result.id = self._flash_ids[event_index]
+#         result.time = self._flash_t0s[event_index*8]/1000. #TO DO: why are there 8 entries? (TPC times?) How to handle this?#  
 
-        hit_start_index = self._hit_indices[result.id][0]
-        hit_stop_index  = self._hit_indices[result.id][1]
-        sipm_hits = self._sipm_hits[hit_start_index:hit_stop_index]
-        result.PEPerOpDet = cppyy.gbl.std.vector('double')() #Because c++ vectors are not correctly recognized as vectors here, other supera types seem fine
-        for hit in sipm_hits:
-            result.PEPerOpDet.push_back(hit['sum'])
-        result.timeWidth = (sipm_hits['busy_ns'][len(sipm_hits)-1] - sipm_hits['busy_ns'][0])/1000. #check this, busy_ns is  timestamp of peak relative to trigger 
-        return result  
+#         hit_start_index = self._hit_indices[result.id][0]
+#         hit_stop_index  = self._hit_indices[result.id][1]
+#         sipm_hits = self._sipm_hits[hit_start_index:hit_stop_index]
+#         result.PEPerOpDet = cppyy.gbl.std.vector('double')() #Because c++ vectors are not correctly recognized as vectors here, other supera types seem fine
+#         for hit in sipm_hits:
+#             result.PEPerOpDet.push_back(hit['sum'])
+#         result.timeWidth = (sipm_hits['busy_ns'][len(sipm_hits)-1] - sipm_hits['busy_ns'][0])/1000. #check this, busy_ns is  timestamp of peak relative to trigger 
+#         return result  
 
 
-    def FlashDump(self, input_flash):
-        print('-----------EVENT DUMP-----------------')
-        print('Flash ID {}'.format(input_flash.id))
-        print('Flash t0 us {}'.format(input_flash.time))
-        print('Flash width in us {}'.format(input_flash.timeWidth))
+#     def FlashDump(self, input_flash):
+#         print('-----------EVENT DUMP-----------------')
+#         print('Flash ID {}'.format(input_flash.id))
+#         print('Flash t0 us {}'.format(input_flash.time))
+#         print('Flash width in us {}'.format(input_flash.timeWidth))
 
 

--- a/src/flow2supera/reader.py
+++ b/src/flow2supera/reader.py
@@ -28,9 +28,7 @@ class FlowReader:
         self._backtracked_hits = None
         self._segments = None
         self._trajectories = None
-        #self._vertices = None
         self._interactions = None
-        #self._if_spill = False
         self._run_config = parser_run_config
         self._is_sim = False
 
@@ -72,9 +70,6 @@ class FlowReader:
         segments_path = 'mc_truth/segments/'
         trajectories_path = 'mc_truth/trajectories/data'
 
-        #if type(input_files) == str:
-        #    input_files = [input_files]
-        
         self._is_sim = False 
         # TODO Currently only reading one input file at a time. Is it 
         # necessary to read multiple? If so, how to handle non-unique
@@ -87,10 +82,8 @@ class FlowReader:
             self._event_ids = events_data['id']
             self._event_t0s = flow_manager[events_path, t0s_path]
             self._event_hit_indices = flow_manager[event_hit_indices_path]
-            #self._hits = flow_manager[events_path, calib_final_hits_path]
             self._hits = flow_manager[calib_final_hits_path+'data']
             self._backtracked_hits = flow_manager[backtracked_hits_path]
-            #self._backtracked_hits = fin[backtracked_hits_path]
             self._is_sim = 'mc_truth' in fin.keys()
             if self._is_sim:
                 #self._segments = flow_manager[events_path,
@@ -149,11 +142,9 @@ class FlowReader:
                 trajectory_parent_id = trajectory['parent_id']
                 trajectory_ids.append(trajectory_id)
                 trajectory_ids.append(trajectory_parent_id)
-                #truth_dict['segment_ids'].append(segment_id)
-                #truth_dict['trajectory_ids'].append(trajectory_id)
+
 
         truth_dict['segment_ids'] = segment_ids
-        # Trajectory IDs should increment in order
         truth_dict['trajectory_ids'] = sorted(trajectory_ids)
 
         return truth_dict
@@ -169,37 +160,27 @@ class FlowReader:
 
         result.event_id = self._event_ids[event_index]
 
-        # t0s dtypes: ('id', 'ts', 'ts_err', 'type')
-        # Use 'ts' for event timestamp
+
         result.t0 = self._event_t0s[result.event_id]['ts']
 
         result.hit_indices = self._event_hit_indices[result.event_id]
         hit_start_index = self._event_hit_indices[result.event_id][0]
         hit_stop_index  = self._event_hit_indices[result.event_id][1]
-        #result.hits = self._hits[result.event_id]
         result.hits = self._hits[hit_start_index:hit_stop_index]
         result.backtracked_hits = self._backtracked_hits[hit_start_index:hit_stop_index]
 
         truth_ids_dict = self.GetEventTruthFromHits(result.backtracked_hits, 
                                                     self._segments, 
                                                     self._trajectories)
-        #result.trajectories = self._trajectories
         event_trajectory_ids = truth_ids_dict['trajectory_ids']
         trajectories_array = np.array(self._trajectories)
         result.trajectories = trajectories_array[np.isin(trajectories_array['traj_id'], event_trajectory_ids)]
 
-        #result.segments = self._segments[result.event_id]
         event_segment_ids = truth_ids_dict['segment_ids']
         segments_array = np.array(self._segments)
         result.segments = segments_array[np.isin(segments_array['segment_id'], event_segment_ids)]
 
-        #result.segments = self._segments
-        #result.segments = self._segments[self._segments['event_id']==result.event_id]
-        # Keep trajectories as-is and use the segments' traj_id to get event trajectories in driver
-        #result.trajectories = self._trajectories[self._trajectories['event_id']==result.event_id]
-        #result.trajectories = self._trajectories
-        #result.interactions = self._interactions[result.event_id]
-        #result.segment_index_min = mask.nonzero()[0][0]
+
         result.interactions = self._interactions
         
         return result  
@@ -213,8 +194,5 @@ class FlowReader:
         print('hits shape:', input_event.hits.shape)
         print('segments in this event:', len(input_event.segments))
         print('trajectories in this event:', len(input_event.trajectories))
-        #print('trajectories:', input_event.trajectories)
-        #print('segments:', input_event.segments)
-        #print('trajectories:', input_event.trajectories)
         print('interactions in this event:', len(input_event.interactions))
 

--- a/src/flow2supera/reader.py
+++ b/src/flow2supera/reader.py
@@ -102,7 +102,6 @@ class FlowReader:
                 self._trajectories = flow_manager[trajectories_path]
                 self._interactions = flow_manager[interactions_path]
 
-        print('woo')
                 
         # This next bit is only necessary if reading multiple files
         # Stack datasets so that there's a "file index" preceding the event index
@@ -136,7 +135,6 @@ class FlowReader:
 
         segment_ids = []
         trajectory_ids = []
-
         for i_bt, backtracked_hit in enumerate(backtracked_hits):
             for contrib in range(max_contributors):
                 if abs(backtracked_hit['fraction'][contrib]) < hit_threshold: continue

--- a/src/flow2supera/reader.py
+++ b/src/flow2supera/reader.py
@@ -80,7 +80,7 @@ class FlowReader:
             events = flow_manager[events_path]
             events_data = events['data']
             self._event_ids = events_data['id']
-            self._event_t0s = flow_manager[events_path, t0s_path]
+            self._event_t0s = events_data['ts_start']
             self._event_hit_indices = flow_manager[event_hit_indices_path]
             self._hits = flow_manager[calib_final_hits_path+'data']
             self._backtracked_hits = flow_manager[backtracked_hits_path]
@@ -161,7 +161,7 @@ class FlowReader:
         result.event_id = self._event_ids[event_index]
 
 
-        result.t0 = self._event_t0s[result.event_id]['ts']
+        result.t0 = self._event_t0s[result.event_id]
 
         result.hit_indices = self._event_hit_indices[result.event_id]
         hit_start_index = self._event_hit_indices[result.event_id][0]

--- a/src/flow2supera/utils.py
+++ b/src/flow2supera/utils.py
@@ -72,16 +72,16 @@ def log_supera_integrity_check(data, driver, log, verbose=False):
     log['out_cluster_sum'].append(cluster_sum)
     log['out_unass_sum'].append(unass_sum)
     
-def larcv_flash(f):
+# def larcv_flash(f):
         
-    larf=larcv.Flash()
+#     larf=larcv.Flash()
     
-    larf.id              (int(f.id))
-    larf.time            (f.time)
-    larf.timeWidth       (f.timeWidth)
-    larf.PEPerOpDet      (f.PEPerOpDet)
-    # 
-    return larf
+#     larf.id              (int(f.id))
+#     larf.time            (f.time)
+#     larf.timeWidth       (f.timeWidth)
+#     larf.PEPerOpDet      (f.PEPerOpDet)
+#     # 
+#     return larf
 
 # Fill SuperaAtomic class and hand off to label-making
 def run_supera(out_file='larcv.root',
@@ -215,29 +215,29 @@ def run_supera(out_file='larcv.root',
             logger['time_store'   ].append(time_store)
             logger['time_event'   ].append(time_event)
         
-    print("----------------Processing light events----------------")
-    for entry in range(len(reader_flash)):
-        #FIXME: this loop also adds entry to other branches
-        if num_flash_skip and entry < num_flash_skip:
-            continue
+#     print("----------------Processing light events----------------")
+#     for entry in range(len(reader_flash)):
+#         #FIXME: this loop also adds entry to other branches
+#         if num_flash_skip and entry < num_flash_skip:
+#             continue
 
-        if num_flash_events <= 0:
-            break
+#         if num_flash_events <= 0:
+#             break
 
-        num_flash_events -= 1 
+#         num_flash_events -= 1 
 
-        print(f'Processing Entry {entry}')
+#         print(f'Processing Entry {entry}')
 
       
-        input_flash_data = reader_flash.GetFlash(entry)
-        reader_flash.FlashDump(input_flash_data)
+#         input_flash_data = reader_flash.GetFlash(entry)
+#         reader_flash.FlashDump(input_flash_data)
 
-        flash_data = larcv_flash(input_flash_data)
-        flash = writer.get_data("opflash", "sipm_hits")
-        flash.append(flash_data) 
+#         flash_data = larcv_flash(input_flash_data)
+#         flash = writer.get_data("opflash", "sipm_hits")
+#         flash.append(flash_data) 
             
-        writer.set_id(0, 0, int(input_flash_data.id))
-        writer.save_entry()
+#         writer.set_id(0, 0, int(input_flash_data.id))
+#         writer.save_entry()
 
 
     writer.finalize()

--- a/src/flow2supera/utils.py
+++ b/src/flow2supera/utils.py
@@ -99,7 +99,7 @@ def run_supera(out_file='larcv.root',
     writer = get_iomanager(out_file)
     driver = get_flow2supera(config_key)
     reader = flow2supera.reader.FlowReader(driver.parser_run_config(), in_file)
-    reader_flash = flow2supera.reader.FlowFlashReader(driver.parser_run_config(), in_file)
+    #reader_flash = flow2supera.reader.FlowFlashReader(driver.parser_run_config(), in_file)
 
     id_vv = ROOT.std.vector("std::vector<unsigned long>")()
     value_vv = ROOT.std.vector("std::vector<float>")()
@@ -109,8 +109,8 @@ def run_supera(out_file='larcv.root',
 
     if num_events < 0:
         num_events = len(reader)
-    if num_flash_events < 0:
-        num_flash_events = len(reader_flash)
+    # if num_flash_events < 0:
+    #     num_flash_events = len(reader_flash)
 
     print("--- startup {:.2e} seconds ---".format(time.time() - start_time))
 

--- a/src/flow2supera/utils.py
+++ b/src/flow2supera/utils.py
@@ -176,7 +176,13 @@ def run_supera(out_file='larcv.root',
                 continue
             larp = larcv_particle(p)
             particle.append(larp)
-
+            
+        #propagating trigger info
+        trigger = writer.get_data("trigger", "base")
+        trigger.id(int(input_data.event_id))  # fixme: this will need to be different for real data?
+        trigger.time_s(int(input_data.t0))
+        trigger.time_ns(int(1e9 * (input_data.t0 - trigger.time_s())))
+        
         # TODO fill the run ID 
         writer.set_id(0, 0, int(input_data.event_id))
         writer.save_entry()


### PR DESCRIPTION
Changes include:

1. Cleaning printouts
2. New BBox values based on `larnd2supera`
3. Include negative contribution from backtracked hits (based on `larnd2supera`)
4. New variable `gen_id` added for propagating  G4ID 
5. Propagated trigger info including updating the path of t0 in reader